### PR TITLE
Fix adapters docs URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ export default function () {
 			}
 
 			builder.log.warn(
-				'Could not detect a supported production environment. See https://kit.svelte.dev/docs#adapters to learn how to configure your app to run on the platform of your choosing'
+				'Could not detect a supported production environment. See https://kit.svelte.dev/docs/adapters to learn how to configure your app to run on the platform of your choosing'
 			);
 		}
 	};


### PR DESCRIPTION
The intended URL seems to be `/docs/adapters` as opposed to `/docs#adapters` which leads to the introduction.